### PR TITLE
refactor(itemmanager): 重构物品管理器

### DIFF
--- a/src/main/kotlin/top/maplex/arim/Arim.kt
+++ b/src/main/kotlin/top/maplex/arim/Arim.kt
@@ -5,6 +5,7 @@ import top.maplex.arim.tools.conditionevaluator.ConditionEvaluator
 import top.maplex.arim.tools.entitymatch.EntityMatch
 import top.maplex.arim.tools.fixedcalculator.FixedCalculator
 import top.maplex.arim.tools.glow.api.IGlow
+import top.maplex.arim.tools.itemmanager.ItemManager
 import top.maplex.arim.tools.itemmatch.ItemMatch
 import top.maplex.arim.tools.variablecalculator.VariableCalculator
 import top.maplex.arim.tools.weightrandom.WeightRandom
@@ -67,4 +68,5 @@ object Arim {
      */
     val weightRandom by lazy {  WeightRandom() }
 
+    val itemManager by lazy { ItemManager() }
 }

--- a/src/main/kotlin/top/maplex/arim/tools/itemmanager/ItemManager.kt
+++ b/src/main/kotlin/top/maplex/arim/tools/itemmanager/ItemManager.kt
@@ -1,0 +1,70 @@
+package top.maplex.arim.tools.itemmanager
+
+import org.bukkit.entity.Player
+import taboolib.common.platform.function.info
+import taboolib.common.platform.function.warning
+import taboolib.module.chat.colored
+import top.maplex.arim.tools.itemmanager.source.*
+import java.util.concurrent.ConcurrentHashMap
+
+class ItemManager {
+    private val sources = ConcurrentHashMap<String, ItemSource>()
+
+    operator fun get(source: String): ItemSource? {
+        return sources[source]
+    }
+
+    init {
+        listOf(
+            SourceAzureFlow(),
+            SourceCraftEngine(),
+            SourceItemsAdder(),
+            SourceMinecraft(),
+            SourceMMOItems(),
+            SourceMythic(),
+            SourceNeigeItems(),
+            SourceOraxen(),
+            SourcePxRpg(),
+            SourceSXItem(),
+            SourceZaphkiel()
+        ).forEach(::register)
+    }
+
+    fun register(instance: ItemSource) {
+        if (sources.contains(instance.name)) {
+            info("已存在 &c${instance.name} &r物品源挂钩，请勿重新挂钩".colored())
+            return
+        }
+        if (instance.isLoaded) {
+            sources += instance.name to instance
+            info("已挂钩软依赖 &c${instance.pluginName} &r作为物品源".colored())
+        }
+    }
+
+    fun getSource(source: String): ItemSource {
+        val noHookMsg = "解析物品源 $source 未挂钩"
+        return sources.values.firstOrNull {
+            it.name == source || it.alias.contains(source)
+        } ?: sources["minecraft"]!!.also { warning(noHookMsg.colored()) }
+    }
+
+    /**
+     * @param id 物品ID
+     * @sample "minecraft:stone"
+     */
+    fun parse2ItemStack(id: String, player: Player? = null): BuildSourceItem {
+        val split = id.split(":")
+        var source = split[0]
+        val itemID = split.getOrElse(1) { source.also { source = "minecraft" } }
+
+        var sourceName = "Minecraft"
+        val itemStack = try {
+            val s = getSource(source)
+            s.build(itemID.trim(), player).also { sourceName = s.pluginName }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            getSource("Minecraft").build(itemID.trim(), player)
+        }
+        return BuildSourceItem(player, itemID, itemStack, sourceName)
+    }
+}

--- a/src/main/kotlin/top/maplex/arim/tools/itemmanager/ItemSource.kt
+++ b/src/main/kotlin/top/maplex/arim/tools/itemmanager/ItemSource.kt
@@ -65,73 +65,9 @@ interface ItemSource {
 
     companion object {
 
-        private val sources = ConcurrentHashMap<String, ItemSource>()
-
         @JvmStatic
-        operator fun get(source: String): ItemSource? {
-            return sources[source]
-        }
-
-        private fun getPluginLoaded(pluginName: String): Boolean {
+        fun getPluginLoaded(pluginName: String): Boolean {
             return Bukkit.getPluginManager().getPlugin(pluginName) != null
-        }
-
-        @Awake(LifeCycle.ACTIVE)
-        fun registerSource() {
-            listOf(
-                SourceAzureFlow(),
-                SourceCraftEngine(),
-                SourceItemsAdder(),
-                SourceMinecraft(),
-                SourceMMOItems(),
-                SourceMythic(),
-                SourceNeigeItems(),
-                SourceOraxen(),
-                SourcePxRpg(),
-                SourceSXItem(),
-                SourceZaphkiel()
-            ).forEach(Companion::register)
-        }
-
-        @JvmStatic
-        fun register(instance: ItemSource) {
-            if (sources.contains(instance.name)) {
-                info("已存在 &c${instance.name} &r物品源挂钩，请勿重新挂钩".colored())
-                return
-            }
-            if (instance.isLoaded) {
-                sources += instance.name to instance
-                info("已挂钩软依赖 &c${instance.pluginName} &r作为物品源".colored())
-            }
-        }
-
-        @JvmStatic
-        fun getSource(source: String): ItemSource {
-            val noHookMsg = "解析物品源 $source 未挂钩"
-            return sources.values.firstOrNull {
-                it.name == source || it.alias.contains(source)
-            } ?: sources["minecraft"]!!.also { warning(noHookMsg.colored()) }
-        }
-
-        /**
-         * @param id 物品ID
-         * @sample "minecraft:stone"
-         */
-        @JvmStatic
-        fun parse2ItemStack(id: String, player: Player? = null): BuildSourceItem {
-            val split = id.split(":")
-            var source = split[0]
-            val itemID = split.getOrElse(1) { source.also { source = "minecraft" } }
-
-            var sourceName = "Minecraft"
-            val itemStack = try {
-                val s = getSource(source)
-                s.build(itemID.trim(), player).also { sourceName = s.pluginName }
-            } catch (e: Exception) {
-                e.printStackTrace()
-                getSource("Minecraft").build(itemID.trim(), player)
-            }
-            return BuildSourceItem(player, itemID, itemStack, sourceName)
         }
     }
 }


### PR DESCRIPTION
- 将 ItemSource 中的静态方法移动到 ItemManager 类中懒加载
- 优化了物品源的注册和获取逻辑
- 调整了 parse2ItemStack 方法的实现
- 移除了 ItemSource 中的冗余代码