### PR TITLE
引入了数学表达式 Kether 语句

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     java
     `maven-publish`
-    id("io.izzel.taboolib") version "2.0.22"
+    id("io.izzel.taboolib") version "2.0.23"
     kotlin("jvm") version "1.8.22"
 }
 
@@ -57,6 +57,8 @@ dependencies {
     compileOnly("ink.ptms:Zaphkiel:2.0.14")
     compileOnly("net.momirealms:craft-engine-core:0.0.22")
     compileOnly("net.momirealms:craft-engine-bukkit:0.0.22")
+    /** 数学表达式 **/
+    compileOnly("com.notkamui.libs:keval:1.1.1")
 }
 
 tasks.withType<JavaCompile> {

--- a/src/main/kotlin/top/maplex/arim/kether/MathAction.kt
+++ b/src/main/kotlin/top/maplex/arim/kether/MathAction.kt
@@ -1,0 +1,23 @@
+package top.maplex.arim.kether
+
+import com.notkamui.keval.Keval
+import taboolib.module.kether.KetherParser
+import taboolib.module.kether.combinationParser
+
+/**
+ * 用法
+ *
+ * arim-math (1+1)*10.5/0.5
+ *
+ * 由于 Java15+ 移除 Nashorn JavaScript，则使用 Keval 替代完成数学运算
+ */
+@KetherParser(["arim-math"], shared = true)
+fun parseMath() = combinationParser {
+    it.group(
+        text()
+    ).apply(it) { math ->
+        now {
+            Keval.eval(math)
+        }
+    }
+}


### PR DESCRIPTION
本次改动包含：

- 将 Taboolib 插件版本从 2.0.22 升级到 2.0.23。
- 添加 Keval 数学表达式库依赖。
- 使用 Keval 库替代 Nashorn JavaScript 完成数学运算。
- 支持复杂的数学表达式计算，例如 (1+1)*10.5/0.5。
- 通过 KetherParser 注解注册 arim-math 动作。

提交本次改动的主要原因不再依赖已废弃的 Nashorn JavaScript 引擎完成数学表达式运算。

- 用法示例 1: set a to 10 arim-math inline "2+{{ get a }}"
- 用法示例 2: arim-math "(1+1)*10.5/0.5"